### PR TITLE
security: remove unnecessary host_permissions from manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,9 +7,6 @@
     "storage",
     "unlimitedStorage"
   ],
-  "host_permissions": [
-    "https://gemini.google.com/*"
-  ],
   "background": {
     "service_worker": "background.js",
     "scripts": ["background.js"]


### PR DESCRIPTION
our content-script is injected automatically, not programmatically. There is no network request either. So we don't need this host permission for gemini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated permissions in the manifest file by removing access to "https://gemini.google.com/*".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->