### PR TITLE
feat: use system color scheme preference as default theme

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -163,10 +163,10 @@ export function initTheme(callback) {
         theme = result[THEME_STORAGE_KEY];
         Logger.log(`Retrieved stored theme preference: ${theme}`);
       } else {
-        // Default to system preference via CSS media query, but track as 'light'
-        // The CSS will handle the system preference via @media (prefers-color-scheme: dark)
-        theme = 'light';
-        Logger.log('No stored theme preference, defaulting to light with system detection via CSS');
+        // Default to system preference by checking prefers-color-scheme
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = prefersDark ? 'dark' : 'light';
+        Logger.log(`No stored theme preference, defaulting to system preference: ${theme}`);
       }
       
       if (callback && typeof callback === 'function') {


### PR DESCRIPTION
Instead of hardcoding 'light' as the default theme when no user preference exists, now detects and uses the user's system preference (dark/light) via the prefers-color-scheme media query. This provides a more seamless user experience by respecting system settings from first use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved theme initialization to explicitly set light or dark mode based on system preference when no stored preference is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->