### PR TITLE
fix/initial theme flash

### DIFF
--- a/src/dashboard/App.vue
+++ b/src/dashboard/App.vue
@@ -237,22 +237,13 @@ onMounted(async () => {
 async function initializeDashboard() {
   isLoading.value = true;
   try {
-    // Get the theme that was already set in the HTML (don't reset it)
-    // This ensures we work with the same theme value that was applied before rendering
-    try {
-      const currentAppliedTheme = document.documentElement.getAttribute('data-theme') || 'light';
-      currentTheme.value = currentAppliedTheme;
-    } catch (e) {
-      Logger.error('Error getting current theme:', e);
-    }
+    // Get the theme that was already set in main.js
+    currentTheme.value = document.documentElement.getAttribute('data-theme') || 'light';
     
-    // Initialize theme system and ensure our reactive state matches what's stored
-    initTheme((themeValue) => {
-      currentTheme.value = themeValue;
-      if (headerComponent.value) {
-        applyTheme(currentTheme.value, headerComponent.value.themeIconSvg);
-      }
-    });
+    // Initialize theme toggle icon if needed
+    if (headerComponent.value) {
+      applyTheme(currentTheme.value, headerComponent.value.themeIconSvg);
+    }
 
     // Load history data using the helper function
     allHistory.value = await loadHistoryData();

--- a/src/dashboard/App.vue
+++ b/src/dashboard/App.vue
@@ -237,7 +237,16 @@ onMounted(async () => {
 async function initializeDashboard() {
   isLoading.value = true;
   try {
-    // Initialize theme
+    // Get the theme that was already set in the HTML (don't reset it)
+    // This ensures we work with the same theme value that was applied before rendering
+    try {
+      const currentAppliedTheme = document.documentElement.getAttribute('data-theme') || 'light';
+      currentTheme.value = currentAppliedTheme;
+    } catch (e) {
+      Logger.error('Error getting current theme:', e);
+    }
+    
+    // Initialize theme system and ensure our reactive state matches what's stored
     initTheme((themeValue) => {
       currentTheme.value = themeValue;
       if (headerComponent.value) {

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -60,9 +60,10 @@ html[data-theme='dark'] {
   --toast-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
-/* System preference dark mode */
+/* System preference dark mode - only applies when no explicit theme is set */
 @media (prefers-color-scheme: dark) {
-  html:not([data-theme='light']) {
+  html:not([data-theme]), 
+  html[data-theme='dark'] {
     --primary-color: #8b68f0;
     --primary-dark: #6e41e2;
     --primary-light: #a88ff8;
@@ -77,6 +78,22 @@ html[data-theme='dark'] {
     --danger-color: #f44336;
     --danger-hover: #d32f2f;
     --shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  }
+}
+
+/* Set background color directly on HTML element to prevent flash */
+html {
+  background-color: #f9f9fb; /* Light theme default */
+}
+
+html[data-theme='dark'] {
+  background-color: #121212; /* Dark theme default */
+}
+
+/* System preference dark mode - ensure no flash on initial load */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    background-color: #121212; /* Dark theme default based on system preference */
   }
 }
 

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -81,15 +81,6 @@ html[data-theme='dark'] {
   }
 }
 
-/* Set background color directly on HTML element to prevent flash */
-html {
-  background-color: #f9f9fb; /* Light theme default */
-}
-
-html[data-theme='dark'] {
-  background-color: #121212; /* Dark theme default */
-}
-
 /* System preference dark mode - ensure no flash on initial load */
 @media (prefers-color-scheme: dark) {
   html:not([data-theme]) {

--- a/src/dashboard/dashboard.html
+++ b/src/dashboard/dashboard.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gemini History Manager - Full View</title>
+  <!-- Critical CSS for theme initialization to prevent flash -->
+  <link rel="stylesheet" href="theme-init.css">
   <link rel="stylesheet" href="dashboard.css">
 </head>
 <body>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -22,18 +22,24 @@
       document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
     }
     
-    // After a small delay, remove the transition-disabling class
-    setTimeout(() => {
-      document.documentElement.classList.remove('initial-load');
-    }, 300); // Wait for the page to stabilize
+    // Enable transitions only after the rendering is complete
+    // Using requestAnimationFrame is more reliable than a timeout
+    requestAnimationFrame(() => {
+      // Using a second requestAnimationFrame ensures we wait for the painting to complete
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove('initial-load');
+      });
+    });
     
   } catch (e) {
     console.error('[Gemini History] Error setting initial theme:', e);
     // Default to light theme if there's an error
     document.documentElement.setAttribute('data-theme', 'light');
-    setTimeout(() => {
-      document.documentElement.classList.remove('initial-load');
-    }, 300);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove('initial-load');
+      });
+    });
   }
 })();
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3,8 +3,42 @@
  * Initializes and mounts the Vue application for the main dashboard page.
  */
 
+// Apply theme immediately before any rendering or Vue initialization
+// This prevents any flash of unthemed content
+(function applyInitialTheme() {
+  // Start with the initial load class that disables all transitions
+  document.documentElement.classList.add('initial-load');
+  
+  try {
+    // CRITICAL: This needs to happen as fast as possible to avoid any flash
+    const savedTheme = localStorage.getItem('geminiHistoryTheme');
+    
+    if (savedTheme) {
+      // Set the data-theme attribute immediately from localStorage
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    } else {
+      // If no saved theme, check system preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    }
+    
+    // After a small delay, remove the transition-disabling class
+    setTimeout(() => {
+      document.documentElement.classList.remove('initial-load');
+    }, 300); // Wait for the page to stabilize
+    
+  } catch (e) {
+    console.error('[Gemini History] Error setting initial theme:', e);
+    // Default to light theme if there's an error
+    document.documentElement.setAttribute('data-theme', 'light');
+    setTimeout(() => {
+      document.documentElement.classList.remove('initial-load');
+    }, 300);
+  }
+})();
+
 import { createApp } from 'vue'; // Import createApp function from Vue
-import App from './App.vue';     // Import the root Vue component for the dashboard (we'll create this next)
+import App from './App.vue';     // Import the root Vue component for the dashboard
 
 // Optionally, import dashboard.css here if you want Vite to process it.
 // It's currently linked in dashboard.html.

--- a/src/dashboard/theme-init.css
+++ b/src/dashboard/theme-init.css
@@ -1,0 +1,38 @@
+/* 
+ * Theme initialization CSS
+ * Critical CSS loaded before the main stylesheet to prevent flash of wrong theme
+ */
+
+/* Default light theme background - will be overridden by system preferences or explicit theme setting */
+html {
+  background-color: #f9f9fb; 
+  color: #333;
+}
+
+/* Explicit dark theme */
+html[data-theme='dark'] {
+  background-color: #121212; 
+  color: #e0e0e0;
+}
+
+/* Explicit light theme - must override system preference */
+html[data-theme='light'] {
+  background-color: #f9f9fb !important;
+  color: #333 !important;
+}
+
+/* System preference dark mode */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    background-color: #121212;
+    color: #e0e0e0;
+  }
+}
+
+/* Disable all transitions during initial page load to prevent flickering */
+.initial-load * {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -o-transition: none !important;
+  transition: none !important;
+}

--- a/src/dashboard/theme-init.css
+++ b/src/dashboard/theme-init.css
@@ -1,38 +1,31 @@
 /* 
  * Theme initialization CSS
- * Critical CSS loaded before the main stylesheet to prevent flash of wrong theme
+ * Critical CSS loaded before the main stylesheet to prevent theme flash
  */
 
-/* Default light theme background - will be overridden by system preferences or explicit theme setting */
+/* Default light theme background */
 html {
   background-color: #f9f9fb; 
-  color: #333;
 }
 
 /* Explicit dark theme */
 html[data-theme='dark'] {
   background-color: #121212; 
-  color: #e0e0e0;
 }
 
 /* Explicit light theme - must override system preference */
 html[data-theme='light'] {
   background-color: #f9f9fb !important;
-  color: #333 !important;
 }
 
-/* System preference dark mode */
+/* System preference dark mode - for when the theme attribute isn't set yet */
 @media (prefers-color-scheme: dark) {
   html:not([data-theme]) {
     background-color: #121212;
-    color: #e0e0e0;
   }
 }
 
-/* Disable all transitions during initial page load to prevent flickering */
+/* Disable transitions during initial page load to prevent flickering */
 .initial-load * {
-  -webkit-transition: none !important;
-  -moz-transition: none !important;
-  -o-transition: none !important;
   transition: none !important;
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -155,7 +155,21 @@ export const THEME_STORAGE_KEY = 'geminiHistoryTheme';
  * @param {function} callback - Function to call with the theme value once determined
  */
 export function initTheme(callback) {
-  // Get stored theme preference
+  // Check localStorage first for immediate access
+  try {
+    const localTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    if (localTheme) {
+      Logger.log(`Retrieved theme from localStorage: ${localTheme}`);
+      if (callback && typeof callback === 'function') {
+        callback(localTheme);
+      }
+      return;
+    }
+  } catch (error) {
+    Logger.error('Error accessing localStorage for theme:', error);
+  }
+  
+  // Get stored theme preference from browser.storage if localStorage doesn't have it
   browser.storage.local.get(THEME_STORAGE_KEY)
     .then(result => {
       let theme;

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -85,10 +85,15 @@ onMounted(async () => {
   
   // Enable transitions only after the app is fully initialized and rendered
   // This prevents theme transition flash on initial load
-  setTimeout(() => {
-    document.documentElement.classList.add('ready-for-transitions');
-    Logger.log("Transitions enabled");
-  }, 100); // Short delay to ensure rendering is complete
+  // Using requestAnimationFrame is more reliable than a timeout as it
+  // ensures we wait for the next rendering cycle to complete
+  requestAnimationFrame(() => {
+    // Using a second requestAnimationFrame ensures we wait for the painting to complete
+    requestAnimationFrame(() => {
+      document.documentElement.classList.add('ready-for-transitions');
+      Logger.log("Transitions enabled");
+    });
+  });
 });
 
 async function initializePopup() {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -81,10 +81,14 @@ const errorState = ref({ hasError: false, message: '' });
 // --- Initialization and Data Loading ---
 onMounted(async () => {
   Logger.log("Popup App.vue: Component mounted");
-  // Enable transitions only after component is mounted
-  // This prevents theme transition flash on initial load
-  document.documentElement.classList.add('ready-for-transitions');
   await initializePopup();
+  
+  // Enable transitions only after the app is fully initialized and rendered
+  // This prevents theme transition flash on initial load
+  setTimeout(() => {
+    document.documentElement.classList.add('ready-for-transitions');
+    Logger.log("Transitions enabled");
+  }, 100); // Short delay to ensure rendering is complete
 });
 
 async function initializePopup() {
@@ -93,7 +97,7 @@ async function initializePopup() {
   try {
     await loadExtensionVersion();
     // Initialize theme and then apply it, passing the SVG ref
-    // Note: Initial theme was already applied by inline script in HTML
+    // Note: Initial theme was already applied by script in main.js before Vue mounts
     initTheme((themeValue) => {
       currentTheme.value = themeValue;
       // Apply theme to icon after component is mounted

--- a/src/popup/main.js
+++ b/src/popup/main.js
@@ -3,22 +3,25 @@
  * Initializes and mounts the Vue application for the browser action popup.
  */
 
-// Immediately apply theme to prevent flash
-try {
-  // For browser extensions, we need to use the synchronous localStorage
-  // as browser.storage.local is async and may not be immediately available
-  const savedTheme = localStorage.getItem('geminiHistoryTheme');
-  // Apply theme immediately to prevent flash
-  if (savedTheme) {
-    document.documentElement.setAttribute('data-theme', savedTheme);
-  } else {
-    // Maintain light theme explicitly set in HTML tag as fallback
-    // <html data-theme="light">
+// This code will run before the DOM content is fully loaded
+// Apply theme immediately as early as possible to prevent flash
+// We use this approach instead of inline script due to extension CSP restrictions
+(function applyInitialTheme() {
+  try {
+    const savedTheme = localStorage.getItem('geminiHistoryTheme');
+    if (savedTheme) {
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    } else {
+      // If no saved theme, check system preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    }
+  } catch (e) {
+    console.error('[Gemini History] Error setting initial theme:', e);
+    // Default to light theme if there's an error
+    document.documentElement.setAttribute('data-theme', 'light');
   }
-} catch (e) {
-  console.error('Error setting initial theme:', e);
-  // The fallback is already set in the HTML tag
-}
+})();
 
 import { createApp } from 'vue'; // Import createApp function from Vue
 import App from './App.vue';     // Import the root Vue component (we'll create this next)

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -41,16 +41,17 @@ html[data-theme='dark'] {
   }
 }
 
-/* Add a class that will be applied once the Vue app is mounted */
-html.ready-for-transitions * {
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
-}
-
+/* No transitions by default to prevent theme flash */
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  /* No transitions by default - they'll be enabled after initial render */
+  transition: none !important; /* Explicitly disable all transitions by default */
+}
+
+/* Add a class that will be applied once the Vue app is mounted */
+html.ready-for-transitions * {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease !important;
 }
 
 body {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
finally, the problem #39  should be fixed now. But just in case, let's not merge it immediately. 
fixes #39

The latest push partially addresses #48 as well, about the moon icon and extra state. But it still doesn't fix the wrong theme initialization. (right now it only happens on light mode, which default to dark mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved theme initialization to apply dark or light mode instantly based on user preference or system settings, reducing flashes of unthemed content during page load.
  - Added a dedicated stylesheet to ensure correct background color before the app fully loads.

- **Bug Fixes**
  - Prevented visual flashes and unwanted transitions when switching themes or loading the app.

- **Style**
  - Enhanced CSS to better handle dark mode and background color transitions.
  - Explicitly disabled transitions on initial load, enabling them only after the app is ready.

- **Documentation**
  - Updated comments to clarify the theme initialization sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->