### PR TITLE
fix/update badge upon import

### DIFF
--- a/src/dashboard/App.vue
+++ b/src/dashboard/App.vue
@@ -449,15 +449,15 @@ async function handleFileSelectedForImport(event) {
     
     const fileContent = await readFile(file);
     
-    // Use the helper function to import data
-    const { newItems, updatedHistory } = importHistoryData(fileContent, allHistory.value);
+    // Use the helper function to import data - now with await since the function is async
+    const { newItems, updatedHistory } = await importHistoryData(fileContent, allHistory.value);
     
     if (newItems.length > 0) {
       // Update history with imported data
       allHistory.value = updatedHistory;
       
-      // Save merged data
-      await saveData();
+      // No need to save again as importHistoryData now handles saving
+      // await saveData(); 
       updateDashboardStats();
       
       if (activeMainTab.value === 'visualizations') {


### PR DESCRIPTION
Fixes #62 

Update badge count upon import by sending a message to background script 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of the history import process, ensuring data is fully saved before completing the import.
	- Badge count now updates automatically after importing or saving conversation history.

- **Chores**
	- Streamlined the import logic for better performance and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->