### PR TITLE
detect veo version from the tooltip HTML

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
@@ -76,10 +76,10 @@
           const tooltipText = tooltip.textContent.trim();
           Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
 
-          if (tooltipText === "Generate with Veo 3") {
+          if (tooltipText.includes("Veo 3")) {
             Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
             return "Veo 3";
-          } else if (tooltipText === "Generate with Veo 2") {
+          } else if (tooltipText.includes("Veo 2")) {
             Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
             return "Veo 2";
           }

--- a/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
@@ -92,7 +92,7 @@
 
         if (buttonText.includes("Video")) {
           Logger.log("gemini-tracker", "Video tool is activated, checking for Veo version...");
-          
+
           // Check for tooltip to determine if it's Veo 2 or Veo 3
           const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
           if (tooltipContainer) {
@@ -100,7 +100,7 @@
             for (const tooltip of tooltips) {
               const tooltipText = tooltip.textContent.trim();
               Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
-              
+
               if (tooltipText === "Generate with Veo 3") {
                 Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
                 return "Veo 3";
@@ -110,7 +110,7 @@
               }
             }
           }
-          
+
           // Fallback to Veo 2 if tooltip detection fails
           Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
           return "Veo 2";
@@ -139,8 +139,11 @@
             'button.toolbox-drawer-item-button.is-selected[aria-pressed="true"]'
           );
           if (videoButton) {
-            Logger.log("gemini-tracker", "Video tool is activated (detected via icon), checking for Veo version...");
-            
+            Logger.log(
+              "gemini-tracker",
+              "Video tool is activated (detected via icon), checking for Veo version..."
+            );
+
             // Check for tooltip to determine if it's Veo 2 or Veo 3
             const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
             if (tooltipContainer) {
@@ -148,7 +151,7 @@
               for (const tooltip of tooltips) {
                 const tooltipText = tooltip.textContent.trim();
                 Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
-                
+
                 if (tooltipText === "Generate with Veo 3") {
                   Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
                   return "Veo 3";
@@ -158,7 +161,7 @@
                 }
               }
             }
-            
+
             // Fallback to Veo 2 if tooltip detection fails
             Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
             return "Veo 2";

--- a/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
@@ -63,8 +63,37 @@
     },
 
     /**
+     * Detects the Veo version based on tooltip text.
+     *
+     * @returns {string} - Returns "Veo 3" or "Veo 2" (defaults to "Veo 2" if version can't be determined)
+     */
+    detectVeoVersion: function () {
+      // Check for tooltip to determine if it's Veo 2 or Veo 3
+      const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
+      if (tooltipContainer) {
+        const tooltips = tooltipContainer.querySelectorAll("[role='tooltip']");
+        for (const tooltip of tooltips) {
+          const tooltipText = tooltip.textContent.trim();
+          Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
+
+          if (tooltipText === "Generate with Veo 3") {
+            Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
+            return "Veo 3";
+          } else if (tooltipText === "Generate with Veo 2") {
+            Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
+            return "Veo 2";
+          }
+        }
+      }
+
+      // Fallback to Veo 2 if tooltip detection fails
+      Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
+      return "Veo 2";
+    },
+
+    /**
      * Checks if any special tools are activated in the toolbox drawer.
-     * Looks for "Deep Research" and "Video" (Veo 2) tools.
+     * Looks for "Deep Research" and "Video" (Veo 2/3) tools.
      *
      * @returns {string|null} - Returns the special model name if detected, or null if none detected
      */
@@ -92,28 +121,7 @@
 
         if (buttonText.includes("Video")) {
           Logger.log("gemini-tracker", "Video tool is activated, checking for Veo version...");
-
-          // Check for tooltip to determine if it's Veo 2 or Veo 3
-          const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
-          if (tooltipContainer) {
-            const tooltips = tooltipContainer.querySelectorAll("[role='tooltip']");
-            for (const tooltip of tooltips) {
-              const tooltipText = tooltip.textContent.trim();
-              Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
-
-              if (tooltipText === "Generate with Veo 3") {
-                Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
-                return "Veo 3";
-              } else if (tooltipText === "Generate with Veo 2") {
-                Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
-                return "Veo 2";
-              }
-            }
-          }
-
-          // Fallback to Veo 2 if tooltip detection fails
-          Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
-          return "Veo 2";
+          return this.detectVeoVersion();
         }
       }
 
@@ -143,28 +151,7 @@
               "gemini-tracker",
               "Video tool is activated (detected via icon), checking for Veo version..."
             );
-
-            // Check for tooltip to determine if it's Veo 2 or Veo 3
-            const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
-            if (tooltipContainer) {
-              const tooltips = tooltipContainer.querySelectorAll("[role='tooltip']");
-              for (const tooltip of tooltips) {
-                const tooltipText = tooltip.textContent.trim();
-                Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
-
-                if (tooltipText === "Generate with Veo 3") {
-                  Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
-                  return "Veo 3";
-                } else if (tooltipText === "Generate with Veo 2") {
-                  Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
-                  return "Veo 2";
-                }
-              }
-            }
-
-            // Fallback to Veo 2 if tooltip detection fails
-            Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
-            return "Veo 2";
+            return this.detectVeoVersion();
           }
         }
       }

--- a/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-model-detector.js
@@ -69,7 +69,7 @@
      * @returns {string|null} - Returns the special model name if detected, or null if none detected
      */
     checkForSpecialTools: function () {
-      Logger.log("gemini-tracker", "Checking for special tools (Deep Research, Veo 2)...");
+      Logger.log("gemini-tracker", "Checking for special tools (Deep Research, Veo)...");
 
       // Get all activated tools in the toolbox drawer
       const activatedButtons = document.querySelectorAll(
@@ -91,7 +91,28 @@
         }
 
         if (buttonText.includes("Video")) {
-          Logger.log("gemini-tracker", "Video tool (Veo 2) is activated");
+          Logger.log("gemini-tracker", "Video tool is activated, checking for Veo version...");
+          
+          // Check for tooltip to determine if it's Veo 2 or Veo 3
+          const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
+          if (tooltipContainer) {
+            const tooltips = tooltipContainer.querySelectorAll("[role='tooltip']");
+            for (const tooltip of tooltips) {
+              const tooltipText = tooltip.textContent.trim();
+              Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
+              
+              if (tooltipText === "Generate with Veo 3") {
+                Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
+                return "Veo 3";
+              } else if (tooltipText === "Generate with Veo 2") {
+                Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
+                return "Veo 2";
+              }
+            }
+          }
+          
+          // Fallback to Veo 2 if tooltip detection fails
+          Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
           return "Veo 2";
         }
       }
@@ -118,7 +139,28 @@
             'button.toolbox-drawer-item-button.is-selected[aria-pressed="true"]'
           );
           if (videoButton) {
-            Logger.log("gemini-tracker", "Video tool (Veo 2) is activated (detected via icon)");
+            Logger.log("gemini-tracker", "Video tool is activated (detected via icon), checking for Veo version...");
+            
+            // Check for tooltip to determine if it's Veo 2 or Veo 3
+            const tooltipContainer = document.querySelector(".cdk-describedby-message-container");
+            if (tooltipContainer) {
+              const tooltips = tooltipContainer.querySelectorAll("[role='tooltip']");
+              for (const tooltip of tooltips) {
+                const tooltipText = tooltip.textContent.trim();
+                Logger.log("gemini-tracker", `Found tooltip with text: "${tooltipText}"`);
+                
+                if (tooltipText === "Generate with Veo 3") {
+                  Logger.log("gemini-tracker", "Veo 3 is detected via tooltip");
+                  return "Veo 3";
+                } else if (tooltipText === "Generate with Veo 2") {
+                  Logger.log("gemini-tracker", "Veo 2 is detected via tooltip");
+                  return "Veo 2";
+                }
+              }
+            }
+            
+            // Fallback to Veo 2 if tooltip detection fails
+            Logger.log("gemini-tracker", "Could not determine Veo version, defaulting to Veo 2");
             return "Veo 2";
           }
         }


### PR DESCRIPTION
Resolves #109 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of "Veo" video tool versions, now distinguishing between "Veo 2" and "Veo 3" based on tooltip information.

- **Bug Fixes**
  - Enhanced accuracy in identifying the correct version of the "Veo" tool when tooltips are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->