### PR TITLE
fix(search): preserve MiniSearch relevance order in search results

### DIFF
--- a/src/dashboard/helpers/searchHelpers.js
+++ b/src/dashboard/helpers/searchHelpers.js
@@ -71,10 +71,10 @@ export function searchHistory(searchIndex, query, allHistory) {
     const searchResults = searchIndex.search(query);
     Logger.debug("searchHelpers", `Found ${searchResults.length} results`);
 
-    // Map search results back to original history entries in MiniSearch result order
-    // This ensures relevance ordering is preserved
+    // Optimize: Use a Map for O(1) lookups from id to entry
+    const idToEntry = new Map(allHistory.map(entry => [(entry.id || ""), entry]));
     const matchedEntries = searchResults
-      .map((result) => allHistory.find((entry) => (entry.id || "") === result.id))
+      .map(result => idToEntry.get(result.id))
       .filter(Boolean); // Remove any not found
 
     // If we didn't find exact matches by ID, try to find by content similarity

--- a/src/dashboard/helpers/searchHelpers.js
+++ b/src/dashboard/helpers/searchHelpers.js
@@ -71,13 +71,11 @@ export function searchHistory(searchIndex, query, allHistory) {
     const searchResults = searchIndex.search(query);
     Logger.debug("searchHelpers", `Found ${searchResults.length} results`);
 
-    // Map search results back to original history entries
-    // We need to do this to maintain the complete object structure
-    const resultMap = new Map(searchResults.map((result) => [result.id, result]));
-    const matchedEntries = allHistory.filter((entry) => {
-      const entryId = entry.id || "";
-      return resultMap.has(entryId);
-    });
+    // Map search results back to original history entries in MiniSearch result order
+    // This ensures relevance ordering is preserved
+    const matchedEntries = searchResults
+      .map((result) => allHistory.find((entry) => (entry.id || "") === result.id))
+      .filter(Boolean); // Remove any not found
 
     // If we didn't find exact matches by ID, try to find by content similarity
     // This is a fallback for entries without IDs or older entries


### PR DESCRIPTION
Fixes #124 

Previously, search results were mapped back to the original history array using a filter, which did not preserve the relevance order returned by MiniSearch. Now, results are reconstructed in the exact order provided by MiniSearch, ensuring that sorting by "Relevance" works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the relevance order of search results in the dashboard, ensuring displayed results match the intended ranking.
  - Resolved an issue where some search results could appear out of order or include entries not present in the history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->