### PR TITLE
fix(settings): ensure LoggingSettings always appears when opening settings tab

### DIFF
--- a/src/dashboard/App.vue
+++ b/src/dashboard/App.vue
@@ -218,6 +218,7 @@ initDayjsPlugins();
 
 // --- Reactive State ---
 const isLoading = ref(true);
+const activeSettingsTab = ref("logging");
 const allHistory = ref([]);
 const searchFilterQuery = ref("");
 const selectedModelFilter = ref("");
@@ -283,6 +284,11 @@ const filteredHistory = computed(() => {
 });
 
 // --- Lifecycle Hooks ---
+// Ensure the settings tab always shows logging settings by default
+watch(activeMainTab, (newTab) => {
+  if (newTab === "settings") activeSettingsTab.value = "logging";
+});
+
 onMounted(async () => {
   Logger.log("App.vue", "Dashboard App.vue: Component mounted");
 


### PR DESCRIPTION
Fixes #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The settings tab now always defaults to the "logging" section when navigating to the settings area, ensuring a consistent starting point for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->