### PR TITLE
add unified version bump script for manifest and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format": "pretty-quick --staged",
     "format:check": "pretty-quick --check --staged",
     "format:all": "prettier --write \"**/*.{js,vue,json,css,md,html}\"",
-    "format:check:all": "prettier --check \"**/*.{js,vue,json,css,md,html}\""
+    "format:check:all": "prettier --check \"**/*.{js,vue,json,css,md,html}\"",
+    "bump": "node scripts/bump-version.js"
   },
   "keywords": [
     "gemini",

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,56 +1,80 @@
 #!/usr/bin/env node
-import fs from 'fs';
-import path from 'path';
+/**
+ * @file bump-version.js
+ * Bumps the version in package.json, src/manifest-chrome.json, and src/manifest-firefox.json.
+ * Usage: pnpm bump --[major|minor|patch] or -[M|m|p]
+ */
+import fs from "fs";
+import path from "path";
 
 const files = [
-  path.join('src', 'manifest-chrome.json'),
-  path.join('src', 'manifest-firefox.json'),
-  'package.json',
+  path.join("src", "manifest-chrome.json"),
+  path.join("src", "manifest-firefox.json"),
+  "package.json",
 ];
 
+/**
+ * Parses CLI arguments to determine the type of version bump.
+ * @returns {('major'|'minor'|'patch')|null} The type of version bump, or null if not specified.
+ */
 function parseArgs() {
-  const arg = process.argv.slice(2).find(a => a.startsWith('-') || a.startsWith('--'));
+  const arg = process.argv.slice(2).find((a) => a.startsWith("-") || a.startsWith("--"));
   if (!arg) return null;
-  if (arg === '--major' || arg === '-M') return 'major';
-  if (arg === '--minor' || arg === '-m') return 'minor';
-  if (arg === '--patch' || arg === '-p') return 'patch';
+  if (arg === "--major" || arg === "-M") return "major";
+  if (arg === "--minor" || arg === "-m") return "minor";
+  if (arg === "--patch" || arg === "-p") return "patch";
   return null;
 }
 
+/**
+ * Bumps the given semantic version string according to the specified type.
+ * @param {string} version - The current version string (e.g., "1.2.3").
+ * @param {'major'|'minor'|'patch'} type - The type of version bump.
+ * @returns {string} The new version string.
+ */
 function bumpVersion(version, type) {
-  let [major, minor, patch] = version.split('.').map(Number);
-  if (type === 'major') {
+  let [major, minor, patch] = version.split(".").map(Number);
+  if (type === "major") {
     major++;
     minor = 0;
     patch = 0;
-  } else if (type === 'minor') {
+  } else if (type === "minor") {
     minor++;
     patch = 0;
-  } else if (type === 'patch') {
+  } else if (type === "patch") {
     patch++;
   }
-  return [major, minor, patch].join('.');
+  return [major, minor, patch].join(".");
 }
 
+/**
+ * Updates the version field in the specified JSON file.
+ * @param {string} file - Path to the JSON file.
+ * @param {string} newVersion - The new version string to set.
+ * @throws If the file does not have a version field.
+ */
 function updateFile(file, newVersion) {
-  const content = fs.readFileSync(file, 'utf-8');
+  const content = fs.readFileSync(file, "utf-8");
   const json = JSON.parse(content);
   if (!json.version) throw new Error(`No version field in ${file}`);
   json.version = newVersion;
-  fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
+  fs.writeFileSync(file, JSON.stringify(json, null, 2) + "\n");
   console.log(`Updated ${file} to version ${newVersion}`);
 }
 
+/**
+ * Main entry point: parses arguments, bumps version, and updates all relevant files.
+ */
 function main() {
   const type = parseArgs();
   if (!type) {
-    console.error('Usage: pnpm bump --[major|minor|patch] or -[M|m|p]');
+    console.error("Usage: pnpm bump --[major|minor|patch] or -[M|m|p]");
     process.exit(1);
   }
   // Read version from package.json
-  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
   const newVersion = bumpVersion(pkg.version, type);
-  files.forEach(file => updateFile(file, newVersion));
+  files.forEach((file) => updateFile(file, newVersion));
 }
 
 main();

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -65,7 +65,16 @@ function updateFile(file, newVersion) {
 /**
  * Main entry point: parses arguments, bumps version, and updates all relevant files.
  */
+/**
+ * Throws an error if more than one CLI argument is provided (excluding node and script path).
+ * Ensures only one version bump argument is allowed.
+ */
 function main() {
+  const userArgs = process.argv.slice(2).filter((a) => a.startsWith("-"));
+  if (userArgs.length > 1) {
+    console.error("Error: Only one argument is allowed.");
+    process.exit(1);
+  }
   const type = parseArgs();
   if (!type) {
     console.error("Usage: pnpm bump --[major|minor|patch] or -[M|m|p]");

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const files = [
+  path.join('src', 'manifest-chrome.json'),
+  path.join('src', 'manifest-firefox.json'),
+  'package.json',
+];
+
+function parseArgs() {
+  const arg = process.argv.slice(2).find(a => a.startsWith('-') || a.startsWith('--'));
+  if (!arg) return null;
+  if (arg === '--major' || arg === '-M') return 'major';
+  if (arg === '--minor' || arg === '-m') return 'minor';
+  if (arg === '--patch' || arg === '-p') return 'patch';
+  return null;
+}
+
+function bumpVersion(version, type) {
+  let [major, minor, patch] = version.split('.').map(Number);
+  if (type === 'major') {
+    major++;
+    minor = 0;
+    patch = 0;
+  } else if (type === 'minor') {
+    minor++;
+    patch = 0;
+  } else if (type === 'patch') {
+    patch++;
+  }
+  return [major, minor, patch].join('.');
+}
+
+function updateFile(file, newVersion) {
+  const content = fs.readFileSync(file, 'utf-8');
+  const json = JSON.parse(content);
+  if (!json.version) throw new Error(`No version field in ${file}`);
+  json.version = newVersion;
+  fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n');
+  console.log(`Updated ${file} to version ${newVersion}`);
+}
+
+function main() {
+  const type = parseArgs();
+  if (!type) {
+    console.error('Usage: pnpm bump --[major|minor|patch] or -[M|m|p]');
+    process.exit(1);
+  }
+  // Read version from package.json
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+  const newVersion = bumpVersion(pkg.version, type);
+  files.forEach(file => updateFile(file, newVersion));
+}
+
+main();


### PR DESCRIPTION
Add a script to automatically bump version in all 3 files. Right now it's a simple script that's vulnerable to common errors such as missing files, missing version field, or versions that don't adhere to semver. But it's alright, the script is intended just for this project anyway.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an automated version bumping feature accessible via a new npm command that updates version numbers across multiple files.
- **Chores**
	- Introduced a new npm script to simplify version management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->