### PR TITLE
correctly detect new conversation item when sidebar is hidden

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -97,10 +97,7 @@
      */
     extractTitleFromSidebarItem: function (conversationItem) {
       Logger.log("gemini-tracker", "Attempting to extract title from sidebar item:", conversationItem);
-      if (conversationItem.offsetParent === null) {
-        Logger.log("Conversation item not visible (hidden). Skipping title extraction.");
-        return null;
-      }
+
       const titleElement = conversationItem.querySelector(".conversation-title");
       if (!titleElement) {
         Logger.warn("gemini-tracker", "Could not find title element (.conversation-title).");
@@ -108,7 +105,7 @@
       }
       Logger.log("gemini-tracker", "Found title container element:", titleElement);
 
-      // Special logic for collapsed sidebar
+      // Special logic for collapsed sidebar - execute first
       if (this.isSidebarCollapsed()) {
         Logger.log("gemini-tracker", "Sidebar is collapsed. Waiting for placeholder...");
         const placeholderPrompt = STATE.pendingPrompt;
@@ -135,9 +132,15 @@
         }
         Logger.warn("gemini-tracker", "Collapsed sidebar: Title was empty.");
         return null;
-      } else {
-        Logger.log("gemini-tracker", "Sidebar is not collapsed. Proceeding with normal extraction logic...");
       }
+
+      // Regular extraction logic - visibility check and normal processing
+      if (conversationItem.offsetParent === null) {
+        Logger.log("Conversation item not visible (hidden). Skipping title extraction.");
+        return null;
+      }
+
+      Logger.log("gemini-tracker", "Sidebar is not collapsed. Proceeding with normal extraction logic...");
 
       // Normal extraction logic (sidebar not collapsed)
       try {

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -533,6 +533,7 @@
         }
 
         // Enhanced observer for collapsed sidebar placeholder logic
+        const self = this; // Store reference to DomObserver for use in callbacks
         STATE.titleObserver = new MutationObserver(() => {
           // Check if URL changed during observation
           if (window.location.href !== expectedUrl) {
@@ -540,8 +541,8 @@
               "gemini-tracker",
               `URL changed from "${expectedUrl}" to "${window.location.href}" while waiting for title. Cleaning up all title observers.`
             );
-            STATE.titleObserver = DomObserver.cleanupObserver(STATE.titleObserver);
-            STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+            STATE.titleObserver = self.cleanupObserver(STATE.titleObserver);
+            STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
             return;
           }
 
@@ -551,13 +552,13 @@
               "gemini-tracker",
               "Conversation item removed from DOM. Cleaning up all title observers."
             );
-            STATE.titleObserver = DomObserver.cleanupObserver(STATE.titleObserver);
-            STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+            STATE.titleObserver = self.cleanupObserver(STATE.titleObserver);
+            STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
             return;
           }
 
           const titleElement = conversationItem.querySelector(".conversation-title");
-          if (DomObserver.isSidebarCollapsed() && titleElement) {
+          if (self.isSidebarCollapsed() && titleElement) {
             const currentTitle = titleElement.textContent.trim();
             const placeholderPrompt = prompt; // Use the passed prompt parameter instead of STATE.pendingPrompt
 
@@ -579,8 +580,8 @@
                       "gemini-tracker",
                       "URL changed during secondary observer. Cleaning up all title observers."
                     );
-                    STATE.titleObserver = DomObserver.cleanupObserver(STATE.titleObserver);
-                    STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+                    STATE.titleObserver = self.cleanupObserver(STATE.titleObserver);
+                    STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
                     return;
                   }
 
@@ -590,18 +591,18 @@
                       "gemini-tracker",
                       "Conversation item or title element removed from DOM. Cleaning up all title observers."
                     );
-                    STATE.titleObserver = DomObserver.cleanupObserver(STATE.titleObserver);
-                    STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+                    STATE.titleObserver = self.cleanupObserver(STATE.titleObserver);
+                    STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
                     return;
                   }
 
                   // Check if sidebar expanded (secondary observer no longer needed)
-                  if (!DomObserver.isSidebarCollapsed()) {
+                  if (!self.isSidebarCollapsed()) {
                     Logger.log(
                       "gemini-tracker",
                       "Sidebar expanded while secondary observer active. Cleaning up secondary observer."
                     );
-                    STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+                    STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
                     return;
                   }
 
@@ -620,7 +621,7 @@
                     STATE.titleObserver.disconnect();
                     STATE.titleObserver = null;
                     // Continue with chat data extraction as usual
-                    DomObserver.processTitleAndAddHistory(
+                    self.processTitleAndAddHistory(
                       newTitle,
                       expectedUrl,
                       timestamp,
@@ -645,8 +646,8 @@
               STATE.titleObserver.disconnect();
               STATE.titleObserver = null;
               // Clean up secondary observer if it exists
-              STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
-              DomObserver.processTitleAndAddHistory(
+              STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
+              self.processTitleAndAddHistory(
                 currentTitle,
                 expectedUrl,
                 timestamp,
@@ -664,11 +665,11 @@
               "gemini-tracker",
               "Sidebar not collapsed but secondary observer exists. Cleaning up secondary observer."
             );
-            STATE.secondaryTitleObserver = DomObserver.cleanupObserver(STATE.secondaryTitleObserver);
+            STATE.secondaryTitleObserver = self.cleanupObserver(STATE.secondaryTitleObserver);
           }
 
           // Normal processing for non-collapsed sidebar
-          DomObserver.processTitleMutations(
+          self.processTitleMutations(
             conversationItem,
             expectedUrl,
             timestamp,

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -93,9 +93,10 @@
      *   - Uses the new title once it changes.
      *
      * @param {Element} conversationItem - The DOM element representing a conversation item
+     * @param {string} [prompt] - The original user prompt to compare against for placeholder detection
      * @returns {string|null} - The extracted title or null if not found
      */
-    extractTitleFromSidebarItem: function (conversationItem) {
+    extractTitleFromSidebarItem: function (conversationItem, prompt = null) {
       Logger.log("gemini-tracker", "Attempting to extract title from sidebar item:", conversationItem);
 
       const titleElement = conversationItem.querySelector(".conversation-title");
@@ -108,7 +109,7 @@
       // Special logic for collapsed sidebar - execute first
       if (this.isSidebarCollapsed()) {
         Logger.log("gemini-tracker", "Sidebar is collapsed. Setting up observer to wait for real title...");
-        const placeholderPrompt = STATE.pendingPrompt;
+        const placeholderPrompt = prompt; // Use the passed prompt parameter instead of STATE.pendingPrompt
         // Try direct text node
         let currentTitle = "";
         try {
@@ -455,7 +456,7 @@
       }
 
       // Extract title and process if found
-      const title = this.extractTitleFromSidebarItem(conversationItem);
+      const title = this.extractTitleFromSidebarItem(conversationItem, prompt);
       const geminiPlan = STATE.pendingGeminiPlan;
       if (
         await this.processTitleAndAddHistory(
@@ -519,7 +520,7 @@
           const titleElement = conversationItem.querySelector(".conversation-title");
           if (DomObserver.isSidebarCollapsed() && titleElement) {
             const currentTitle = titleElement.textContent.trim();
-            const placeholderPrompt = STATE.pendingPrompt;
+            const placeholderPrompt = prompt; // Use the passed prompt parameter instead of STATE.pendingPrompt
 
             // Set up secondary observer if we detect placeholder or empty title
             if (!currentTitle || (placeholderPrompt && currentTitle === placeholderPrompt)) {
@@ -643,7 +644,7 @@
         return true; // Return true to indicate we should stop trying (observer is disconnected)
       }
 
-      const title = this.extractTitleFromSidebarItem(item);
+      const title = this.extractTitleFromSidebarItem(item, prompt);
       Logger.log("gemini-tracker", `TITLE Check (URL: ${expectedUrl}): Extracted title: "${title}"`);
 
       // Get the Gemini Plan from the state

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -512,7 +512,7 @@
         STATE.titleObserver = new MutationObserver(() => {
           const titleElement = conversationItem.querySelector(".conversation-title");
           const placeholderPrompt = STATE.pendingPrompt;
-          if (isSidebarCollapsed() && titleElement) {
+          if (DomObserver.isSidebarCollapsed() && titleElement) {
             const currentTitle = titleElement.textContent.trim();
             if (placeholderPrompt && currentTitle === placeholderPrompt) {
               // Wait for the title to change from the placeholder

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -18,8 +18,7 @@
    * Used when the page becomes visible again after being hidden.
    *
    * @returns {void}
-   */
-  function reinitializeObservers() {
+   */ function reinitializeObservers() {
     Logger.log("gemini-tracker", "Re-initializing observers after page became visible...");
 
     // Re-initialize GemDetector for current URL
@@ -36,8 +35,12 @@
     const STATE = window.GeminiHistory_STATE;
     const isTrackingChat = STATE && STATE.isNewChatPending;
 
-    // Re-establish sidebar watcher
-    if (!isTrackingChat) {
+    // Handle status indicator based on tracking state
+    if (isTrackingChat) {
+      Logger.log("gemini-tracker", "Returning during active chat tracking, restoring status indicator");
+      StatusIndicator.show("Tracking new chat...", "info");
+    } else {
+      // Re-establish sidebar watcher with loading status
       StatusIndicator.show("Reconnecting to Gemini sidebar...", "loading", 0);
     }
 
@@ -246,15 +249,7 @@
         Logger.log("gemini-tracker", "Page hidden, cleaning up all observers");
         DomObserver.cleanupAllObservers();
       } else {
-        const STATE = window.GeminiHistory_STATE;
         Logger.log("gemini-tracker", "Page became visible, re-initializing observers");
-
-        // Check if we're returning during an active chat tracking session
-        if (STATE && STATE.isNewChatPending) {
-          Logger.log("gemini-tracker", "Returning during active chat tracking, restoring status indicator");
-          StatusIndicator.show("Tracking new chat...", "info");
-        }
-
         reinitializeObservers();
       }
     });

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -84,8 +84,13 @@
             "gemini-tracker",
             "URL change is within the same Gem context, maintaining Gem detection"
           );
-        } else if (GemDetector) {
-          GemDetector.reset();
+        } else {
+          // Clean up all observers when navigating to a different context
+          DomObserver.cleanupAllObservers();
+
+          if (GemDetector) {
+            GemDetector.reset();
+          }
         }
 
         lastUrl = currentUrl;
@@ -154,6 +159,31 @@
     });
 
     Logger.log("Gemini History Manager initialization complete.");
+
+    // Add cleanup for page unload to prevent memory leaks
+    /**
+     * Cleans up all observers when the page is being unloaded.
+     * Prevents memory leaks from dangling DOM observers.
+     *
+     * @returns {void}
+     */
+    window.addEventListener("beforeunload", () => {
+      Logger.log("gemini-tracker", "Page unloading, cleaning up all observers");
+      DomObserver.cleanupAllObservers();
+    });
+
+    /**
+     * Cleans up all observers when the page visibility changes (e.g., tab switch).
+     * Additional safety measure for observer cleanup.
+     *
+     * @returns {void}
+     */
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        Logger.log("gemini-tracker", "Page hidden, cleaning up all observers");
+        DomObserver.cleanupAllObservers();
+      }
+    });
   }
 
   // Start the script

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -216,18 +216,18 @@
      * Handles page visibility changes (e.g., tab switch).
      * Cleans up observers when hidden to prevent memory leaks,
      * and re-initializes them when visible again to restore functionality.
-     * Does not cleanup if a title observer is active (Gemini is currently responding).
+     * Does not cleanup if a new chat is pending (Gemini is currently responding).
      *
      * @returns {void}
      */
     document.addEventListener("visibilitychange", () => {
       if (document.hidden) {
-        // Check if a title observer is active (Gemini is currently responding to chat)
+        // Check if Gemini is currently processing a new chat
         const STATE = window.GeminiHistory_STATE;
-        if (STATE && (STATE.titleObserver || STATE.secondaryTitleObserver)) {
+        if (STATE && STATE.isNewChatPending) {
           Logger.log(
             "gemini-tracker",
-            "Page hidden, but title observer is active (Gemini responding). Skipping cleanup to preserve chat tracking."
+            "Page hidden, but new chat is pending (Gemini responding). Skipping cleanup to preserve chat tracking."
           );
           return;
         }

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -216,11 +216,22 @@
      * Handles page visibility changes (e.g., tab switch).
      * Cleans up observers when hidden to prevent memory leaks,
      * and re-initializes them when visible again to restore functionality.
+     * Does not cleanup if a title observer is active (Gemini is currently responding).
      *
      * @returns {void}
      */
     document.addEventListener("visibilitychange", () => {
       if (document.hidden) {
+        // Check if a title observer is active (Gemini is currently responding to chat)
+        const STATE = window.GeminiHistory_STATE;
+        if (STATE && (STATE.titleObserver || STATE.secondaryTitleObserver)) {
+          Logger.log(
+            "gemini-tracker",
+            "Page hidden, but title observer is active (Gemini responding). Skipping cleanup to preserve chat tracking."
+          );
+          return;
+        }
+
         Logger.log("gemini-tracker", "Page hidden, cleaning up all observers");
         DomObserver.cleanupAllObservers();
       } else {

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -228,24 +228,24 @@
 
     /**
      * Handles page visibility changes (e.g., tab switch).
-     * Cleans up observers when hidden to prevent memory leaks,
-     * and re-initializes them when visible again to restore functionality.
-     * Does not cleanup if a new chat is pending (Gemini is currently responding).
+     * Completely skips all observer cleanup and re-initialization when a chat is in progress.
+     * Only processes visibility changes when no chat tracking is active.
      *
      * @returns {void}
      */
     document.addEventListener("visibilitychange", () => {
-      if (document.hidden) {
-        // Check if Gemini is currently processing a new chat
-        const STATE = window.GeminiHistory_STATE;
-        if (STATE && STATE.isNewChatPending) {
-          Logger.log(
-            "gemini-tracker",
-            "Page hidden, but new chat is pending (Gemini responding). Skipping cleanup to preserve chat tracking."
-          );
-          return;
-        }
+      // Check if Gemini is currently processing a new chat - if so, do NOTHING
+      const STATE = window.GeminiHistory_STATE;
+      if (STATE && STATE.isNewChatPending) {
+        Logger.log(
+          "gemini-tracker",
+          `Page visibility changed, but new chat is pending. Doing absolutely nothing to preserve chat tracking.`
+        );
+        return;
+      }
 
+      // Only handle visibility changes when no chat is in progress
+      if (document.hidden) {
         Logger.log("gemini-tracker", "Page hidden, cleaning up all observers");
         DomObserver.cleanupAllObservers();
       } else {

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -235,7 +235,15 @@
         Logger.log("gemini-tracker", "Page hidden, cleaning up all observers");
         DomObserver.cleanupAllObservers();
       } else {
+        const STATE = window.GeminiHistory_STATE;
         Logger.log("gemini-tracker", "Page became visible, re-initializing observers");
+
+        // Check if we're returning during an active chat tracking session
+        if (STATE && STATE.isNewChatPending) {
+          Logger.log("gemini-tracker", "Returning during active chat tracking, restoring status indicator");
+          StatusIndicator.show("Tracking new chat...", "info");
+        }
+
         reinitializeObservers();
       }
     });

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -32,11 +32,22 @@
       }
     }
 
+    // Check if we're currently tracking a chat
+    const STATE = window.GeminiHistory_STATE;
+    const isTrackingChat = STATE && STATE.isNewChatPending;
+
     // Re-establish sidebar watcher
-    StatusIndicator.show("Reconnecting to Gemini sidebar...", "loading", 0);
+    if (!isTrackingChat) {
+      StatusIndicator.show("Reconnecting to Gemini sidebar...", "loading", 0);
+    }
+
     DomObserver.watchForSidebar((sidebar) => {
       Logger.log("gemini-tracker", "Sidebar re-detected after page visibility change. Manager fully active.");
-      StatusIndicator.show("Gemini History Manager active", "success");
+
+      // Only show "active" status if we're not tracking a chat
+      if (!isTrackingChat) {
+        StatusIndicator.show("Gemini History Manager active", "success");
+      }
     });
   }
 

--- a/src/content-scripts/gemini-tracker/gemini-history-state.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-state.js
@@ -14,6 +14,7 @@
     pendingGemUrl: null,
     sidebarObserver: null,
     titleObserver: null,
+    secondaryTitleObserver: null,
   };
 
   window.GeminiHistory_STATE = STATE;

--- a/src/content-scripts/gemini-tracker/gemini-history-utils.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-utils.js
@@ -102,6 +102,28 @@
       const userAccountPattern = /^https:\/\/gemini\.google\.com\/u\/\d+\/app(\?.*)?$/;
       return userAccountPattern.test(url);
     },
+
+    /**
+     * Determines if a URL transition represents new chat creation that should preserve observers.
+     * This helps distinguish between navigation away from chat context vs. new chat creation.
+     *
+     * @param {string} fromUrl - The previous URL
+     * @param {string} toUrl - The current URL
+     * @returns {boolean} - True if this transition should preserve observers for chat detection
+     */
+    isNewChatTransition: function (fromUrl, toUrl) {
+      // Regular new chat: base app URL -> chat URL
+      const isRegularNewChat =
+        this.isBaseAppUrl(fromUrl) && this.isValidChatUrl(toUrl) && !this.isGemChatUrl(toUrl);
+
+      // Gem new chat: gem homepage -> gem chat with same gem ID
+      const isGemNewChat =
+        this.isGemHomepageUrl(fromUrl) &&
+        this.isGemChatUrl(toUrl) &&
+        this.extractGemId(fromUrl) === this.extractGemId(toUrl);
+
+      return isRegularNewChat || isGemNewChat;
+    },
   };
 
   window.GeminiHistory_Utils = Utils;


### PR DESCRIPTION
Fixes #144 
implement a special title detector that executes when the sidebar is collapsed. Basically, it deploys an extra observer to watch until the placeholder title changes into something different. 

This new logic can potentially be promoted as the default extraction logic. The default logic relies on visibility, which might be unreliable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection and extraction of conversation titles when the Gemini sidebar is collapsed, ensuring accurate history recording even when placeholder titles are shown.
- **Bug Fixes**
  - Enhanced robustness in tracking conversation titles by handling scenarios where the sidebar displays placeholder or empty titles until the real title appears.
- **Chores**
  - Added comprehensive cleanup of observers on page unload, visibility changes, and URL navigation to prevent memory leaks.
  - Implemented observer reinitialization when the page becomes visible again after being hidden.
  - Preserved observers during new chat creation URL transitions to maintain tracking continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->