### PR TITLE
fix: add stop button monitoring to prevent infinite waiting for titles

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-state.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-state.js
@@ -16,6 +16,7 @@
     sidebarObserver: null,
     titleObserver: null,
     secondaryTitleObserver: null,
+    stopButtonObserver: null,
   };
 
   window.GeminiHistory_STATE = STATE;


### PR DESCRIPTION
Fixes #173 

Basically, it monitors the stop button in parallel with the title. If the title hasn't found after the stop button is vanished, it'll wait 1 second more. If still not found, then accept the placeholder title as the real title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of chat completion by monitoring the visibility of the stop button in the chat interface.
  - Enhanced title extraction logic to capture and save chat titles immediately upon chat completion, even if the title is a placeholder or truncated.

- **Bug Fixes**
  - Improved reliability of chat title saving by ensuring titles are accepted as soon as chat generation finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->