### PR TITLE
refactor: eliminate redundant account info extraction in chat tracking

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -269,13 +269,11 @@
 
     /**
      * Captures context information for a new conversation.
-     * Retrieves current state information to associate with a new chat.
+     * Uses pre-captured data from STATE to avoid redundant data extraction.
      *
      * @returns {Object} - Object containing context details for the conversation
      */
     captureConversationContext: function () {
-      const accountInfo = InputExtractor.getAccountInfo();
-
       return {
         timestamp: Utils.getCurrentTimestamp(),
         url: window.location.href,
@@ -283,8 +281,8 @@
         prompt: STATE.pendingPrompt,
         originalPrompt: STATE.pendingOriginalPrompt,
         attachedFiles: STATE.pendingAttachedFiles,
-        accountName: accountInfo.name,
-        accountEmail: accountInfo.email,
+        accountName: STATE.pendingAccountName,
+        accountEmail: STATE.pendingAccountEmail,
         geminiPlan: STATE.pendingGeminiPlan,
         gemId: STATE.pendingGemId,
         gemName: STATE.pendingGemName,

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -36,7 +36,7 @@
 
     /**
      * Prepares for tracking a new chat.
-     * Captures necessary information before the chat is created.
+     * Captures all necessary information once before the chat is created to avoid redundant data extraction.
      */
     prepareNewChatTracking: function () {
       const url = window.location.href;


### PR DESCRIPTION
## PR Notes by Copilot + Sonnet 4

### **Problem**
The chat tracking system was performing redundant data extraction operations, leading to:
- **Double DOM queries** for account information during new chat creation
- **Potential data inconsistency** between initial capture and final processing
- **Unnecessary performance overhead** from duplicate extraction calls

**Log analysis revealed two separate data capture attempts:**
1. `EventHandlers.prepareNewChatTracking()` captured data on send button click
2. `DomObserver.captureConversationContext()` re-extracted account info again

### **Solution**
Eliminated redundant data extraction by implementing a **single-capture approach**:

- ✅ **Removed duplicate `getAccountInfo()` call** from `captureConversationContext()`
- ✅ **Updated function to use pre-captured STATE data** (`STATE.pendingAccountName`, `STATE.pendingAccountEmail`)
- ✅ **Enhanced JSDoc documentation** to clarify streamlined approach

### **Changes Made**

#### gemini-history-dom-observer.js
- **Refactored** `captureConversationContext()` to use pre-captured account data from STATE
- **Removed** redundant `InputExtractor.getAccountInfo()` call
- **Updated** JSDoc to reflect optimized single-capture strategy

#### gemini-history-event-handlers.js
- **Enhanced** JSDoc documentation for `prepareNewChatTracking()` to clarify its role as the single data capture point