### PR TITLE
standardize log prefixes

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -311,7 +311,7 @@
       }
 
       console.log(
-        `[${new Date().toTimeString().slice(0, 8)}] [GHM] [URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
+        `[${Utils.getPrefix()}] [URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
       );
 
       if (!STATE.isNewChatPending) {
@@ -392,7 +392,7 @@
         childList: true,
         subtree: true,
       });
-      console.log(`[${new Date().toTimeString().slice(0, 8)}] [GHM] [MAIN sidebar observer is now active.`);
+      console.log(`[${Utils.getPrefix()}] [MAIN sidebar observer is now active.`);
     },
 
     /**

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -305,13 +305,13 @@
 
       if (!Utils.isValidChatUrl(currentUrl)) {
         console.log(
-          `[${Utils.getPrefix()}] URL "${currentUrl}" does not match the expected chat pattern. Waiting...`
+          `${Utils.getPrefix()} URL "${currentUrl}" does not match the expected chat pattern. Waiting...`
         );
         return false; // URL still not a valid chat URL
       }
 
       console.log(
-        `[${Utils.getPrefix()}] URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
+        `${Utils.getPrefix()} URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
       );
 
       if (!STATE.isNewChatPending) {
@@ -335,7 +335,7 @@
         // Clear prompt context, but keep isNewChatPending and Gem-related state until title is captured
         this.resetPendingPromptContext();
         console.log(
-          `[${Utils.getPrefix()}] Cleared pending prompt context. Waiting for title associated with URL: ${context.url}`
+          `${Utils.getPrefix()} Cleared pending prompt context. Waiting for title associated with URL: ${context.url}`
         );
 
         // Stage 2: Wait for the Title
@@ -367,7 +367,7 @@
 
       if (!conversationListElement) {
         console.warn(
-          `[${Utils.getPrefix()}] Could not find conversation list element ("${targetSelector}") to observe. Aborting observation setup.`
+          `${Utils.getPrefix()} Could not find conversation list element ("${targetSelector}") to observe. Aborting observation setup.`
         );
         StatusIndicator.show("Could not track chat (UI element not found)", "warning");
         // Full abort - reset all pending state
@@ -392,7 +392,7 @@
         childList: true,
         subtree: true,
       });
-      console.log(`[${Utils.getPrefix()}] MAIN sidebar observer is now active.`);
+      console.log(`${Utils.getPrefix()} MAIN sidebar observer is now active.`);
     },
 
     /**
@@ -438,7 +438,7 @@
           const GemDetector = window.GeminiHistory_GemDetector;
           if (GemDetector && typeof GemDetector.extractGemNameFromResponses === "function") {
             console.log(
-              `[${Utils.getPrefix()}] No gem name was detected earlier. Attempting to extract from response containers...`
+              `${Utils.getPrefix()} No gem name was detected earlier. Attempting to extract from response containers...`
             );
             // Try to extract the gem name from response containers which appear after responses are completed
             const extractedName = GemDetector.extractGemNameFromResponses();
@@ -446,7 +446,7 @@
               gemName = extractedName;
               STATE.pendingGemName = extractedName;
               console.log(
-                `[${Utils.getPrefix()}] Successfully extracted gem name "${gemName}" from response container`
+                `${Utils.getPrefix()} Successfully extracted gem name "${gemName}" from response container`
               );
             }
           }
@@ -454,7 +454,7 @@
 
         if (gemId) {
           console.log(
-            `[${Utils.getPrefix()}] Including Gem info - ID: ${gemId}, Name: ${gemName || "Not detected"}`
+            `${Utils.getPrefix()} Including Gem info - ID: ${gemId}, Name: ${gemName || "Not detected"}`
           );
         }
 
@@ -589,7 +589,7 @@
           ) {
             if (!STATE.secondaryTitleObserver) {
               console.log(
-                `[${Utils.getPrefix()}] Setting up secondary observer to wait for real title change (avoiding truncated titles)...`
+                `${Utils.getPrefix()} Setting up secondary observer to wait for real title change (avoiding truncated titles)...`
               );
 
               // Capture the current title state to compare against
@@ -652,7 +652,7 @@
                   Utils.isTruncatedVersionEnhanced(placeholderPrompt, newTitle, originalPrompt)
                 ) {
                   console.log(
-                    `[${Utils.getPrefix()}] Secondary observer: Detected truncated title "${newTitle}", continuing to wait for full title...`
+                    `${Utils.getPrefix()} Secondary observer: Detected truncated title "${newTitle}", continuing to wait for full title...`
                   );
                 }
               });

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -311,7 +311,7 @@
       }
 
       console.log(
-        `[${Utils.getPrefix()}] [URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
+        `[${Utils.getPrefix()}] URL check passed (matches chat pattern). Processing mutations to find NEW conversation item...`
       );
 
       if (!STATE.isNewChatPending) {
@@ -392,7 +392,7 @@
         childList: true,
         subtree: true,
       });
-      console.log(`[${Utils.getPrefix()}] [MAIN sidebar observer is now active.`);
+      console.log(`[${Utils.getPrefix()}] MAIN sidebar observer is now active.`);
     },
 
     /**

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -25,9 +25,7 @@
       }
 
       if (sendButton.getAttribute("aria-disabled") === "true") {
-        console.log(
-          `[${new Date().toTimeString().slice(0, 8)}] [GHM] [EventHandlers] Send button is disabled. Ignoring click.`
-        );
+        console.log(`[${Utils.getPrefix()}] [EventHandlers] Send button is disabled. Ignoring click.`);
         return false;
       }
 
@@ -44,9 +42,7 @@
         `[${Utils.getPrefix()}] URL ${url} matches valid Gemini pattern. This is potentially a new chat.`
       );
       STATE.isNewChatPending = true;
-      console.log(
-        `[${new Date().toTimeString().slice(0, 8)}] [GHM] [EventHandlers] Set isNewChatPending = true`
-      );
+      console.log(`[${Utils.getPrefix()}] [EventHandlers] Set isNewChatPending = true`);
 
       StatusIndicator.show("Preparing to track new chat...", "loading", 0);
 
@@ -90,9 +86,7 @@
 
       // Use setTimeout to ensure observation starts after the click event potentially triggers initial DOM changes
       setTimeout(() => {
-        console.log(
-          `[${new Date().toTimeString().slice(0, 8)}] [GHM] [EventHandlers] Initiating sidebar observation via setTimeout.`
-        );
+        console.log(`[${Utils.getPrefix()}] [EventHandlers] Initiating sidebar observation via setTimeout.`);
         DomObserver.observeSidebarForNewChat();
       }, 50); // Small delay
     },

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -25,7 +25,7 @@
       }
 
       if (sendButton.getAttribute("aria-disabled") === "true") {
-        console.log(`[${Utils.getPrefix()}] [EventHandlers] Send button is disabled. Ignoring click.`);
+        console.log(`${Utils.getPrefix()} [EventHandlers] Send button is disabled. Ignoring click.`);
         return false;
       }
 
@@ -39,10 +39,10 @@
     prepareNewChatTracking: function () {
       const url = window.location.href;
       console.log(
-        `[${Utils.getPrefix()}] URL ${url} matches valid Gemini pattern. This is potentially a new chat.`
+        `${Utils.getPrefix()} URL ${url} matches valid Gemini pattern. This is potentially a new chat.`
       );
       STATE.isNewChatPending = true;
-      console.log(`[${Utils.getPrefix()}] [EventHandlers] Set isNewChatPending = true`);
+      console.log(`${Utils.getPrefix()} [EventHandlers] Set isNewChatPending = true`);
 
       StatusIndicator.show("Preparing to track new chat...", "loading", 0);
 
@@ -61,7 +61,7 @@
           STATE.pendingGemName = gemInfo.gemName;
           STATE.pendingGemUrl = gemInfo.gemUrl;
           console.log(
-            `[${Utils.getPrefix()}] Captured Gem information: ID=${gemInfo.gemId}, Name=${gemInfo.gemName || "Not detected yet"}`
+            `${Utils.getPrefix()} Captured Gem information: ID=${gemInfo.gemId}, Name=${gemInfo.gemName || "Not detected yet"}`
           );
         }
       }
@@ -86,7 +86,7 @@
 
       // Use setTimeout to ensure observation starts after the click event potentially triggers initial DOM changes
       setTimeout(() => {
-        console.log(`[${Utils.getPrefix()}] [EventHandlers] Initiating sidebar observation via setTimeout.`);
+        console.log(`${Utils.getPrefix()} [EventHandlers] Initiating sidebar observation via setTimeout.`);
         DomObserver.observeSidebarForNewChat();
       }, 50); // Small delay
     },
@@ -110,7 +110,7 @@
           this.prepareNewChatTracking();
         } else {
           console.log(
-            `[${Utils.getPrefix()}] URL is not a valid starting point for new chats. Ignoring click for history tracking.`
+            `${Utils.getPrefix()} URL is not a valid starting point for new chats. Ignoring click for history tracking.`
           );
         }
       }

--- a/src/content-scripts/gemini-tracker/gemini-history-gem-detector.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-gem-detector.js
@@ -101,7 +101,7 @@
           );
 
           // Log the HTML content to help with debugging
-          console.debug(`[${Utils.getPrefix()}] Primary gem container HTML: ${gemNameElement.innerHTML}`);
+          console.debug(`${Utils.getPrefix()} Primary gem container HTML: ${gemNameElement.innerHTML}`);
         }
       }
 
@@ -144,9 +144,7 @@
           );
 
           // Log the HTML content to help with debugging
-          console.debug(
-            `[${Utils.getPrefix()}] Response gem container HTML: ${responseGemElement.innerHTML}`
-          );
+          console.debug(`${Utils.getPrefix()} Response gem container HTML: ${responseGemElement.innerHTML}`);
         }
       }
 
@@ -244,7 +242,7 @@
       // Look for potential bot name containers with different selectors
       const potentialContainers = document.querySelectorAll("[class*='bot-name'], [class*='name-container']");
       console.log(
-        `[${Utils.getPrefix()}] Found ${potentialContainers.length} potential name containers with alternative selectors`
+        `${Utils.getPrefix()} Found ${potentialContainers.length} potential name containers with alternative selectors`
       );
 
       for (let i = 0; i < Math.min(potentialContainers.length, 5); i++) {

--- a/src/content-scripts/gemini-tracker/gemini-history-input-extractor.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-input-extractor.js
@@ -50,7 +50,7 @@
         const limitedText = text.length > 200 ? text.substring(0, 200) : text;
 
         console.log(
-          `[${Utils.getPrefix()}] Extracted original prompt text (limited to 200 chars): "${limitedText}"`
+          `${Utils.getPrefix()} Extracted original prompt text (limited to 200 chars): "${limitedText}"`
         );
         return limitedText;
       } else {
@@ -120,7 +120,7 @@
               accountElement = parent;
               ariaLabel = label;
               console.log(
-                `[${Utils.getPrefix()}] Found account element via profile image with parent having email in aria-label`
+                `${Utils.getPrefix()} Found account element via profile image with parent having email in aria-label`
               );
               break;
             }

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -246,7 +246,7 @@
       const STATE = window.GeminiHistory_STATE;
       if (STATE && STATE.isNewChatPending) {
         console.log(
-          `[${Utils.getPrefix()}] Page visibility changed, but new chat is pending. Doing absolutely nothing to preserve chat tracking.`
+          `${Utils.getPrefix()} Page visibility changed, but new chat is pending. Doing absolutely nothing to preserve chat tracking.`
         );
         return;
       }


### PR DESCRIPTION
Fixes #176 

This PR standardize the leftover `console[method]` calls that still use the old manual timestamp calculation.

update: in the meantime, it also changed [$Utils.getPrefix()] to Utils.getPrefix() to remove extra brackets, since the brackets are already defined in the getPrefix() function. Thanks to @CodeRabbit for catching it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized console log prefixes for improved consistency and readability in logging messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->