### PR TITLE
ensure clear state  on new chat

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -54,6 +54,19 @@
     },
 
     /**
+     * Unified cleanup function that handles both observer cleanup and state reset.
+     * This is the primary cleanup method that should be used in most scenarios.
+     *
+     * @returns {void}
+     */
+    completeCleanup: function () {
+      console.log(`${Utils.getPrefix()} Performing complete cleanup of observers and state...`);
+      this.cleanupAllObservers();
+      this.resetAllPendingState();
+      console.log(`${Utils.getPrefix()} Complete cleanup finished`);
+    },
+
+    /**
      * Helper function to cleanup title observers and clear the new chat pending flag.
      * Only clears the flag when both title observers are cleaned up.
      *
@@ -477,9 +490,9 @@
           StatusIndicator.update("Chat not saved (already exists or invalid)", "info");
         }
 
-        // Complete cleanup: ensure all pending state is cleared after processing
-        console.log(`${Utils.getPrefix()} Chat processing complete, clearing all remaining pending state`);
-        this.resetAllPendingState();
+        // Clear all state after successful completion
+        console.log(`${Utils.getPrefix()} Chat Completed - clearing all state...`);
+        this.completeCleanup();
 
         return true;
       }

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -76,6 +76,7 @@
     /**
      * Cleans up all active observers to prevent memory leaks.
      * Disconnects sidebar, title, and secondary title observers.
+     * Also resets all pending state to ensure clean state for future operations.
      *
      * @returns {void}
      */
@@ -84,6 +85,11 @@
 
       STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
       this.cleanupTitleObservers();
+
+      // Reset all pending state when cleaning up all observers
+      // This ensures no leftover state from incomplete chat tracking
+      console.log(`${Utils.getPrefix()} Resetting all pending state during cleanup`);
+      this.resetAllPendingState();
 
       console.log(`${Utils.getPrefix()} All DOM observers cleaned up`);
     },
@@ -380,9 +386,16 @@
       );
       StatusIndicator.show("Tracking new chat...", "info");
 
-      // Disconnect previous observers if they exist
+      // Disconnect previous observers if they exist and ensure clean state
       STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
       this.cleanupTitleObservers();
+
+      // Ensure we start with clean state for new chat tracking
+      // Only reset pending state if we're not already in a new chat tracking process
+      if (!STATE.isNewChatPending) {
+        console.log(`${Utils.getPrefix()} Cleaning up any leftover state before setting up observers`);
+        this.resetAllPendingState();
+      }
 
       STATE.sidebarObserver = new MutationObserver((mutationsList) => {
         this.processSidebarMutations(mutationsList);
@@ -477,9 +490,9 @@
           StatusIndicator.update("Chat not saved (already exists or invalid)", "info");
         }
 
-        // Note: We don't clear isNewChatPending here because this function is called
-        // immediately when title is found, but observers may still be active.
-        // The flag will be cleared when observers are actually cleaned up.
+        // Complete cleanup: ensure all pending state is cleared after processing
+        console.log(`${Utils.getPrefix()} Chat processing complete, clearing all remaining pending state`);
+        this.resetAllPendingState();
 
         return true;
       }

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -76,7 +76,6 @@
     /**
      * Cleans up all active observers to prevent memory leaks.
      * Disconnects sidebar, title, and secondary title observers.
-     * Also resets all pending state to ensure clean state for future operations.
      *
      * @returns {void}
      */
@@ -85,11 +84,6 @@
 
       STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
       this.cleanupTitleObservers();
-
-      // Reset all pending state when cleaning up all observers
-      // This ensures no leftover state from incomplete chat tracking
-      console.log(`${Utils.getPrefix()} Resetting all pending state during cleanup`);
-      this.resetAllPendingState();
 
       console.log(`${Utils.getPrefix()} All DOM observers cleaned up`);
     },
@@ -386,16 +380,9 @@
       );
       StatusIndicator.show("Tracking new chat...", "info");
 
-      // Disconnect previous observers if they exist and ensure clean state
+      // Disconnect previous observers if they exist
       STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
       this.cleanupTitleObservers();
-
-      // Ensure we start with clean state for new chat tracking
-      // Only reset pending state if we're not already in a new chat tracking process
-      if (!STATE.isNewChatPending) {
-        console.log(`${Utils.getPrefix()} Cleaning up any leftover state before setting up observers`);
-        this.resetAllPendingState();
-      }
 
       STATE.sidebarObserver = new MutationObserver((mutationsList) => {
         this.processSidebarMutations(mutationsList);

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -41,6 +41,14 @@
       console.log(
         `${Utils.getPrefix()} URL ${url} matches valid Gemini pattern. This is potentially a new chat.`
       );
+
+      // Clear all previous state before starting new chat tracking
+      const DomObserver = window.GeminiHistory_DomObserver;
+      if (DomObserver) {
+        console.log(`${Utils.getPrefix()} [EventHandlers] Clearing all previous state before new chat`);
+        DomObserver.resetAllPendingState();
+      }
+
       STATE.isNewChatPending = true;
       console.log(`${Utils.getPrefix()} [EventHandlers] Set isNewChatPending = true`);
 

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -139,12 +139,12 @@
           );
           // Don't cleanup observers - they're needed to capture the new conversation
         } else {
-          // Clean up all observers when navigating to a different context
+          // Clean up all observers and state when navigating to a different context
           // Log URL change using standard prefix
           console.log(
-            `${Utils.getPrefix()} URL change indicates navigation away from chat context, cleaning up observers`
+            `${Utils.getPrefix()} URL change indicates navigation away from chat context, performing complete cleanup`
           );
-          DomObserver.cleanupAllObservers();
+          DomObserver.completeCleanup();
 
           if (GemDetector) {
             GemDetector.reset();


### PR DESCRIPTION
Fixes #184 

clear state before chat (before setting up observers) and after chat (after data saved to history entries)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup process when navigating away from chat, ensuring all observers are disconnected and pending state is reset.
  - Enhanced state management when starting a new chat to prevent leftover data from previous sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->