### PR TITLE
fix chat not finalized when tab is hidden (not focused or opened)

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -588,22 +588,15 @@
       this.observeStopButton(
         expectedUrl,
         () => {
-          console.log(`${Utils.getPrefix()} Stop button observer triggered - attempting to process title`);
-
-          // Try one more time to get a title, and if it's still a placeholder, accept it
+          console.log(
+            `${Utils.getPrefix()} Stop button observer triggered - accepting current title even if placeholder`
+          );
+          // Just accept whatever title is available at this point
           const titleElement = conversationItem.querySelector(".conversation-title");
           if (titleElement) {
             const currentTitle = titleElement.textContent.trim();
-            const placeholderPrompt = prompt;
-
-            // If we have a title and chat has finished, accept it even if it's a placeholder
-            if (
-              currentTitle &&
-              (!placeholderPrompt ||
-                currentTitle === placeholderPrompt ||
-                Utils.isTruncatedVersionEnhanced(placeholderPrompt, currentTitle, originalPrompt))
-            ) {
-              processTitle(currentTitle, "stop button observer (placeholder/truncated)");
+            if (currentTitle) {
+              processTitle(currentTitle, "stop button observer (final acceptance)");
             }
           }
         },


### PR DESCRIPTION
Fixes #190 

This PR introduces 2 changes:
1. centralize the coordination between title observer and stop observer to prevent a race condition
2. modify the stop observer to accept whatever title instead stubbornly still checking isTruncated

Honestly, I expected number 2 to fix the problem, with number 1 as a more like a refactor to ties up loose end and an extra guard. But after checking the log, it's actually number 1 that fixes it. The stop button doesn't even have chance to execute because the title observer already capture the details, which didn't happen previously. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved coordination between chat title and stop button observers to ensure the chat title is processed only once and at the correct time, preventing duplicate or premature title handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->