### PR TITLE
Change the term 'sidebar' into 'recent chats'

### DIFF
--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -88,14 +88,14 @@
 
     /**
      * Cleans up all active observers to prevent memory leaks.
-     * Disconnects sidebar, title, and secondary title observers.
+     * Disconnects conversation list, title, and secondary title observers.
      *
      * @returns {void}
      */
     cleanupAllObservers: function () {
       console.log(`${Utils.getPrefix()} Cleaning up all DOM observers...`);
 
-      STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
+      STATE.conversationListObserver = this.cleanupObserver(STATE.conversationListObserver);
       this.cleanupTitleObservers();
 
       console.log(`${Utils.getPrefix()} All DOM observers cleaned up`);
@@ -137,52 +137,52 @@
     },
 
     /**
-     * Watches for the sidebar element to appear in the DOM.
-     * Calls the provided callback once the sidebar is found.
+     * Watches for the conversation list element to appear in the DOM.
+     * Calls the provided callback once the conversation list is found.
      *
-     * @param {function} callback - Function to call once the sidebar is found
+     * @param {function} callback - Function to call once the conversation list is found
      * @returns {void}
      */
-    watchForSidebar: function (callback) {
-      console.log(`${Utils.getPrefix()} Starting to watch for sidebar element...`);
+    watchForConversationList: function (callback) {
+      console.log(`${Utils.getPrefix()} Starting to watch for conversation list element...`);
       // Show immediate loading status at the beginning
-      StatusIndicator.show("Looking for Gemini sidebar. Please wait...", "loading", 0);
+      StatusIndicator.show("Looking for Gemini conversation list. Please wait...", "loading", 0);
 
-      // First check if the sidebar already exists
-      const sidebarSelector = 'conversations-list[data-test-id="all-conversations"]';
-      const existingSidebar = document.querySelector(sidebarSelector);
+      // First check if the conversation list already exists
+      const conversationListSelector = 'conversations-list[data-test-id="all-conversations"]';
+      const existingConversationList = document.querySelector(conversationListSelector);
 
-      if (existingSidebar) {
-        console.log(`${Utils.getPrefix()} Sidebar already exists in DOM`);
-        callback(existingSidebar);
+      if (existingConversationList) {
+        console.log(`${Utils.getPrefix()} Conversation list already exists in DOM`);
+        callback(existingConversationList);
         return;
       }
 
       // If not, set up an observer to watch for it
-      console.log(`${Utils.getPrefix()} Sidebar not found. Setting up observer to watch for it...`);
+      console.log(`${Utils.getPrefix()} Conversation list not found. Setting up observer to watch for it...`);
 
       const observer = new MutationObserver((mutations, obs) => {
-        const sidebar = document.querySelector(sidebarSelector);
-        if (sidebar) {
-          console.log(`${Utils.getPrefix()} Sidebar element found in DOM`);
+        const conversationList = document.querySelector(conversationListSelector);
+        if (conversationList) {
+          console.log(`${Utils.getPrefix()} Conversation list element found in DOM`);
           obs.disconnect(); // Stop observing once found
-          callback(sidebar);
+          callback(conversationList);
         }
       });
 
-      // Start observing document body for the sidebar element
+      // Start observing document body for the conversation list element
       observer.observe(document.body, {
         childList: true,
         subtree: true,
       });
 
-      // Set a timeout for the case when the sidebar doesn't appear
+      // Set a timeout for the case when the conversation list doesn't appear
       setTimeout(() => {
         if (observer) {
-          const sidebar = document.querySelector(sidebarSelector);
-          if (!sidebar) {
-            console.warn(`${Utils.getPrefix()} Sidebar element not found after timeout`);
-            StatusIndicator.show("Warning: Gemini sidebar not detected", "warning", 0);
+          const conversationList = document.querySelector(conversationListSelector);
+          if (!conversationList) {
+            console.warn(`${Utils.getPrefix()} Conversation list element not found after timeout`);
+            StatusIndicator.show("Warning: Gemini conversation list not detected", "warning", 0);
           }
           observer.disconnect();
         }
@@ -316,14 +316,14 @@
     },
 
     /**
-     * Handles the processing of mutations for the sidebar observer.
+     * Handles the processing of mutations for the conversation list observer.
      *
      * @param {MutationRecord[]} mutationsList - List of mutation records from MutationObserver
      * @returns {boolean} - True if processing was completed, false otherwise
      */
-    processSidebarMutations: function (mutationsList) {
+    processConversationListMutations: function (mutationsList) {
       console.log(
-        `${Utils.getPrefix()} MAIN Sidebar Observer Callback Triggered. ${mutationsList.length} mutations.`
+        `${Utils.getPrefix()} MAIN Conversation List Observer Callback Triggered. ${mutationsList.length} mutations.`
       );
       const currentUrl = window.location.href;
       console.log(`${Utils.getPrefix()} Current URL inside MAIN observer: ${currentUrl}`);
@@ -355,7 +355,7 @@
         const context = this.captureConversationContext();
 
         // Stage 1 Complete: Found the Item - Disconnect the MAIN observer
-        STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
+        STATE.conversationListObserver = this.cleanupObserver(STATE.conversationListObserver);
 
         // Clear prompt context, but keep isNewChatPending and Gem-related state until title is captured
         this.resetPendingPromptContext();
@@ -382,11 +382,11 @@
     },
 
     /**
-     * Sets up observation of the sidebar to detect new chats.
+     * Sets up observation of the conversation list to detect new chats.
      *
      * @returns {void}
      */
-    observeSidebarForNewChat: function () {
+    observeConversationListForNewChat: function () {
       const targetSelector = 'conversations-list[data-test-id="all-conversations"]';
       const conversationListElement = document.querySelector(targetSelector);
 
@@ -401,22 +401,22 @@
       }
 
       console.log(
-        `${Utils.getPrefix()} Found conversation list element. Setting up MAIN sidebar observer...`
+        `${Utils.getPrefix()} Found conversation list element. Setting up MAIN conversation list observer...`
       );
 
       // Disconnect previous observers if they exist
-      STATE.sidebarObserver = this.cleanupObserver(STATE.sidebarObserver);
+      STATE.conversationListObserver = this.cleanupObserver(STATE.conversationListObserver);
       this.cleanupTitleObservers();
 
-      STATE.sidebarObserver = new MutationObserver((mutationsList) => {
-        this.processSidebarMutations(mutationsList);
+      STATE.conversationListObserver = new MutationObserver((mutationsList) => {
+        this.processConversationListMutations(mutationsList);
       });
 
-      STATE.sidebarObserver.observe(conversationListElement, {
+      STATE.conversationListObserver.observe(conversationListElement, {
         childList: true,
         subtree: true,
       });
-      console.log(`${Utils.getPrefix()} MAIN sidebar observer is now active.`);
+      console.log(`${Utils.getPrefix()} MAIN conversation list observer is now active.`);
     },
 
     /**

--- a/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-dom-observer.js
@@ -146,7 +146,7 @@
     watchForConversationList: function (callback) {
       console.log(`${Utils.getPrefix()} Starting to watch for conversation list element...`);
       // Show immediate loading status at the beginning
-      StatusIndicator.show("Looking for Gemini conversation list. Please wait...", "loading", 0);
+      StatusIndicator.show("Looking for Gemini recent chats. Please wait...", "loading", 0);
 
       // First check if the conversation list already exists
       const conversationListSelector = 'conversations-list[data-test-id="all-conversations"]';
@@ -182,7 +182,7 @@
           const conversationList = document.querySelector(conversationListSelector);
           if (!conversationList) {
             console.warn(`${Utils.getPrefix()} Conversation list element not found after timeout`);
-            StatusIndicator.show("Warning: Gemini conversation list not detected", "warning", 0);
+            StatusIndicator.show("Warning: Gemini recent chats not detected", "warning", 0);
           }
           observer.disconnect();
         }

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -92,7 +92,9 @@
 
       // Use setTimeout to ensure observation starts after the click event potentially triggers initial DOM changes
       setTimeout(() => {
-        console.log(`${Utils.getPrefix()} [EventHandlers] Initiating conversation list observation via setTimeout.`);
+        console.log(
+          `${Utils.getPrefix()} [EventHandlers] Initiating conversation list observation via setTimeout.`
+        );
         DomObserver.observeConversationListForNewChat();
       }, 50); // Small delay
     },

--- a/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-event-handlers.js
@@ -92,8 +92,8 @@
 
       // Use setTimeout to ensure observation starts after the click event potentially triggers initial DOM changes
       setTimeout(() => {
-        console.log(`${Utils.getPrefix()} [EventHandlers] Initiating sidebar observation via setTimeout.`);
-        DomObserver.observeSidebarForNewChat();
+        console.log(`${Utils.getPrefix()} [EventHandlers] Initiating conversation list observation via setTimeout.`);
+        DomObserver.observeConversationListForNewChat();
       }, 50); // Small delay
     },
 

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -40,7 +40,7 @@
       StatusIndicator.show("Tracking new chat...", "info");
     } else {
       // Re-establish conversation list watcher with loading status
-      StatusIndicator.show("Reconnecting to Gemini conversation list...", "loading", 0);
+      StatusIndicator.show("Reconnecting to Gemini recent chats...", "loading", 0);
     }
 
     DomObserver.watchForConversationList((conversationList) => {
@@ -92,7 +92,7 @@
     });
 
     // Show immediate status message that persists until conversation list is found (or timeout)
-    StatusIndicator.show("Waiting for Gemini conversation list to appear...", "loading", 0);
+    StatusIndicator.show("Waiting for Gemini recent chats to appear...", "loading", 0);
 
     // Initialize GemDetector and check for Gem information
     const GemDetector = window.GeminiHistory_GemDetector;

--- a/src/content-scripts/gemini-tracker/gemini-history-main.js
+++ b/src/content-scripts/gemini-tracker/gemini-history-main.js
@@ -39,13 +39,13 @@
       console.log(`${Utils.getPrefix()} Returning during active chat tracking, restoring status indicator`);
       StatusIndicator.show("Tracking new chat...", "info");
     } else {
-      // Re-establish sidebar watcher with loading status
-      StatusIndicator.show("Reconnecting to Gemini sidebar...", "loading", 0);
+      // Re-establish conversation list watcher with loading status
+      StatusIndicator.show("Reconnecting to Gemini conversation list...", "loading", 0);
     }
 
-    DomObserver.watchForSidebar((sidebar) => {
+    DomObserver.watchForConversationList((conversationList) => {
       console.log(
-        `${Utils.getPrefix()} Sidebar re-detected after page visibility change. Manager fully active.`
+        `${Utils.getPrefix()} Conversation list re-detected after page visibility change. Manager fully active.`
       );
 
       // Only show "active" status if we're not tracking a chat
@@ -91,8 +91,8 @@
       }
     });
 
-    // Show immediate status message that persists until sidebar is found (or timeout)
-    StatusIndicator.show("Waiting for Gemini sidebar to appear...", "loading", 0);
+    // Show immediate status message that persists until conversation list is found (or timeout)
+    StatusIndicator.show("Waiting for Gemini conversation list to appear...", "loading", 0);
 
     // Initialize GemDetector and check for Gem information
     const GemDetector = window.GeminiHistory_GemDetector;
@@ -168,16 +168,16 @@
       }
     }).observe(document, { subtree: true, childList: true });
 
-    // Watch for sidebar to appear before showing ready status
+    // Watch for conversation list to appear before showing ready status
     /**
-     * Waits for the Gemini sidebar to appear before showing the ready status.
-     * Displays a success message when the sidebar is detected.
+     * Waits for the Gemini conversation list to appear before showing the ready status.
+     * Displays a success message when the conversation list is detected.
      *
-     * @param {HTMLElement} sidebar - The Gemini sidebar element.
+     * @param {HTMLElement} conversationList - The Gemini conversation list element.
      * @returns {void}
      */
-    DomObserver.watchForSidebar((sidebar) => {
-      console.log(`${Utils.getPrefix()} Sidebar confirmed available. Manager fully active.`);
+    DomObserver.watchForConversationList((conversationList) => {
+      console.log(`${Utils.getPrefix()} Conversation list confirmed available. Manager fully active.`);
       StatusIndicator.show("Gemini History Manager active", "success");
     });
 


### PR DESCRIPTION
Resolves #196 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all user-facing references from "sidebar" to "conversation list" in chat tracking features, including status messages and logs.
  - Adjusted method and status names to align with the new "conversation list" terminology for a more accurate user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->