### PR TITLE
import global css through mainjs instead of manual <link> from HTML

### DIFF
--- a/src/dashboard/dashboard.html
+++ b/src/dashboard/dashboard.html
@@ -6,8 +6,6 @@
     <title>Gemini History Manager - Full View</title>
     <!-- Critical CSS for theme initialization to prevent flash -->
     <link rel="stylesheet" href="theme-init.css" />
-    <link rel="stylesheet" href="dashboard.css" />
-    <link rel="stylesheet" href="../assets/css/dashboard.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/dashboard/dashboard.html
+++ b/src/dashboard/dashboard.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gemini History Manager - Full View</title>
-    <!-- Critical CSS for theme initialization to prevent flash -->
-    <link rel="stylesheet" href="theme-init.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -30,9 +30,8 @@ import "../lib/polyfill.js"; // Browser compatibility polyfill
 import { createApp } from "vue"; // Import createApp function from Vue
 import App from "./App.vue"; // Import the root Vue component for the dashboard
 
-// Optionally, import dashboard.css here if you want Vite to process it.
-// It's currently linked in dashboard.html.
-// import './dashboard.css';
+// Import CSS files for Vite to process and bundle
+import "./dashboard.css";
 
 // Create the Vue application instance, using App.vue as the root component
 const app = createApp(App);

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -32,6 +32,7 @@ import App from "./App.vue"; // Import the root Vue component for the dashboard
 
 // Import CSS files for Vite to process and bundle
 import "./dashboard.css";
+import "./theme-init.css";
 
 // Create the Vue application instance, using App.vue as the root component
 const app = createApp(App);

--- a/src/popup/main.js
+++ b/src/popup/main.js
@@ -28,14 +28,10 @@ import { initializeTheme, Logger, THEME_STORAGE_KEY } from "../lib/utils.js";
 
 import "../lib/polyfill.js"; // Browser compatibility polyfill
 import { createApp } from "vue"; // Import createApp function from Vue
-import App from "./App.vue"; // Import the root Vue component (we'll create this next)
+import App from "./App.vue"; // Import the root Vue component
 
-// Optionally, if you want to manage all styles through Vue components,
-// you can import popup.css here. Otherwise, it's already linked in popup.html.
-// If imported here, ensure it's not linked in popup.html to avoid duplication,
-// or ensure the styles are designed to be applied once correctly.
-// For this migration, keeping it in popup.html is fine, but importing here is also an option.
-// import './popup.css';
+// Import CSS files for Vite to process and bundle
+import "./popup.css";
 
 // Create the Vue application instance, using App.vue as the root component
 const app = createApp(App);

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gemini History Manager</title>
-    <link rel="stylesheet" href="popup.css" />
-    <link rel="stylesheet" href="../assets/css/popup.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -136,16 +136,15 @@ export default defineConfig({
             console.log("No content scripts found to copy.");
           }
 
-          // Copy CSS files directly (e.g., dashboard.css, popup.css)
-          // These will be linked from their respective HTML files.
-          // Vue component styles will be handled by Vite and the Vue plugin.
-          const cssFiles = globSync("src/{popup,dashboard}/*.css");
-          cssFiles.forEach((file) => {
-            const relativePath = file.replace(/^src\//, ""); // e.g., popup/popup.css
+          // Copy critical CSS files that are still linked in HTML
+          // theme-init.css is still linked in dashboard.html for critical styling
+          const criticalCssFiles = globSync("src/dashboard/theme-init.css");
+          criticalCssFiles.forEach((file) => {
+            const relativePath = file.replace(/^src\//, ""); // e.g., dashboard/theme-init.css
             const targetPath = path.resolve(__dirname, `${outDir}/${relativePath}`);
             fs.ensureDirSync(path.dirname(targetPath));
             fs.copySync(path.resolve(__dirname, file), targetPath);
-            console.log(`Copied CSS: ${relativePath}`);
+            console.log(`Copied critical CSS: ${relativePath}`);
           });
 
           // Copy background script with browser shim for Chrome

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TARGET_BROWSER = process.env.TARGET_BROWSER || "firefox";
 
 export default defineConfig({
+  base: "./", // Use relative paths for assets
   build: {
     outDir: TARGET_BROWSER === "chrome" ? "dist-chrome" : "dist-firefox",
     emptyOutDir: true,
@@ -20,10 +21,9 @@ export default defineConfig({
     rollupOptions: {
       input: {
         background: path.resolve(__dirname, "src/background.js"),
-        // These are our Vue app entry points
-        // Note: we need these entry points for bundling, but we'll manually handle HTML placement
-        popup: path.resolve(__dirname, "src/popup/main.js"),
-        dashboard: path.resolve(__dirname, "src/dashboard/main.js"),
+        // HTML files as entry points - Vite will process and inject assets automatically
+        popup: path.resolve(__dirname, "src/popup/popup.html"),
+        dashboard: path.resolve(__dirname, "src/dashboard/dashboard.html"),
       },
       output: {
         // Output JS for entry points
@@ -85,26 +85,8 @@ export default defineConfig({
           });
           console.log("Copied icons");
 
-          // Copy and update HTML files (popup.html, dashboard.html)
-          const htmlFiles = globSync("src/{popup,dashboard}/*.html");
-          htmlFiles.forEach((file) => {
-            const relativePath = file.replace(/^src\//, ""); // e.g., popup/popup.html
-            const targetPath = path.resolve(__dirname, `${outDir}/${relativePath}`);
-            const dirName = path.basename(path.dirname(file)); // 'popup' or 'dashboard'
-
-            // Make sure the directory exists
-            fs.ensureDirSync(path.dirname(targetPath));
-
-            // Read HTML content and update JS file references
-            let htmlContent = fs.readFileSync(path.resolve(__dirname, file), "utf-8");
-
-            // Replace references to main.js with the correct JS file name
-            htmlContent = htmlContent.replace(/src="\.\/main\.js"/g, `src="./${dirName}.js"`);
-
-            // Write the modified HTML
-            fs.writeFileSync(targetPath, htmlContent);
-            console.log(`Processed HTML: ${relativePath} (updated script reference to ${dirName}.js)`);
-          });
+          // HTML files are now processed automatically by Vite as entry points
+          // CSS and JS will be automatically injected by Vite
 
           // Copy content scripts directly, preserving subdirectory structure
           const contentScriptSourceBasePath = "src/content-scripts";
@@ -136,17 +118,6 @@ export default defineConfig({
             console.log("No content scripts found to copy.");
           }
 
-          // Copy critical CSS files that are still linked in HTML
-          // theme-init.css is still linked in dashboard.html for critical styling
-          const criticalCssFiles = globSync("src/dashboard/theme-init.css");
-          criticalCssFiles.forEach((file) => {
-            const relativePath = file.replace(/^src\//, ""); // e.g., dashboard/theme-init.css
-            const targetPath = path.resolve(__dirname, `${outDir}/${relativePath}`);
-            fs.ensureDirSync(path.dirname(targetPath));
-            fs.copySync(path.resolve(__dirname, file), targetPath);
-            console.log(`Copied critical CSS: ${relativePath}`);
-          });
-
           // Copy background script with browser shim for Chrome
           const backgroundSource = path.resolve(__dirname, "src/background.js");
           const backgroundTarget = path.resolve(__dirname, `${outDir}/background.js`);
@@ -154,7 +125,29 @@ export default defineConfig({
           // Background script is already processed by Vite build, so we don't need to modify it here
           console.log("Background script processed by Vite build process");
 
-          // Clean up unwanted directories
+          // Move HTML files from src subdirectories to correct locations and fix paths
+          // HTML files are generated in dist-{browser}/src/popup/popup.html etc.
+          const generatedHtmlFiles = globSync(`${outDir}/src/{popup,dashboard}/*.html`);
+          generatedHtmlFiles.forEach((file) => {
+            const relativePath = file.replace(`${outDir}/src/`, ""); // e.g., popup/popup.html
+            const targetPath = path.resolve(__dirname, `${outDir}/${relativePath}`);
+
+            // Make sure the target directory exists
+            fs.ensureDirSync(path.dirname(targetPath));
+
+            // Read and fix the HTML content paths
+            let htmlContent = fs.readFileSync(file, "utf-8");
+
+            // Fix the relative paths - change ../../ to ../
+            htmlContent = htmlContent.replace(/src="\.\.\/\.\.\//g, 'src="../');
+            htmlContent = htmlContent.replace(/href="\.\.\/\.\.\//g, 'href="../');
+
+            // Write the corrected HTML to the target location
+            fs.writeFileSync(targetPath, htmlContent);
+            console.log(`Moved and fixed HTML file: ${relativePath}`);
+          });
+
+          // Clean up unwanted directories after moving HTML files
           if (fs.existsSync(path.resolve(__dirname, `${outDir}/src`))) {
             fs.removeSync(path.resolve(__dirname, `${outDir}/src`));
             console.log(`Cleaned up ${outDir}/src directory`);


### PR DESCRIPTION
Fixes #30

The only possible caveat is the themeinit css. it was meant to be high priority css initialization. will importing them instead of linking directly in html cause flicker due to delay? 

anyway, the refactor is a bigger benefit, so i guess we'll go for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved asset handling by allowing Vite to automatically process and inject CSS and JS into HTML files, removing manual stylesheet links and copying steps.
	- Updated build configuration for more efficient asset bundling and simplified file structure in the output directory.
- **Style**
	- Ensured consistent inclusion of styles across the dashboard and popup interfaces by importing CSS directly into JavaScript entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->