### PR TITLE
docs(readme): add AMO link and clarify install availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _Interactive charts showing model usage over time_
 
 > [!IMPORTANT]
 > - Firefox: Gemini History Manager is available on the Mozilla Add-ons (AMO):
-> https://addons.mozilla.org/en-US/firefox/addon/gemini-history-manager/
+> https://addons.mozilla.org/firefox/addon/gemini-history-manager/
 >
 > - Chrome: Not yet available on the Chrome Web Store. Use the manual installation steps below.
 


### PR DESCRIPTION
Resolves #217 
- Add Firefox AMO listing link
- Note Chrome Web Store not yet available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reflect that the extension is now available on the Mozilla Add-ons (AMO) for Firefox, including a direct link.
  * Clarified that the extension is still unavailable on the Chrome Web Store and provided guidance for manual installation on Chrome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->